### PR TITLE
Remove Useless Vagrant Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Officially tested operating systems are listed in the Galaxy manifest.
 
 ## Role Variables
 
-None.
+<dl>
+  <dt><code>docker_users</code></dt>
+  <dd>A string or list of strings of usernames to add to the <code>docker</code> group.</dd>
+<dl>
 
 ## Dependencies
 
@@ -31,6 +34,18 @@ Simply get that Docker dockering:
   become: true
   roles:
     - role: docker
+```
+
+Add the `vagrant` user to the `docker` group:
+
+```yaml
+---
+- name: install
+  hosts: all
+  become: true
+  roles:
+    - role: docker
+      docker_users: vagrant
 ```
 
 ## License

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -1,7 +1,6 @@
 ---
 - hosts: all
   become: true
-  roles: [docker, vagrant-base]
-  tasks:
-    - name: ensure user is in docker group
-      user: name=vagrant append=true groups=docker
+  vars:
+    docker_users: vagrant
+  roles: [vagrant-base, docker]


### PR DESCRIPTION
Testing locally.

No need for a release after this, this only affects the dev environment.